### PR TITLE
fix #21: sort budget accordion items by amount descending

### DIFF
--- a/internal/core/budget.go
+++ b/internal/core/budget.go
@@ -130,6 +130,11 @@ func computeBudgetView(ctx context.Context, db *sql.DB) (*BudgetView, error) {
 		categories = append(categories, *group)
 		grandTotal += group.Total
 	}
+	for i := range categories {
+		sort.Slice(categories[i].Items, func(a, b int) bool {
+			return categories[i].Items[a].Amount > categories[i].Items[b].Amount
+		})
+	}
 	sort.Slice(categories, func(i, j int) bool {
 		return categories[i].Total > categories[j].Total
 	})


### PR DESCRIPTION
Items within each budget category accordion were appearing in insertion order. Now sorted by amount (largest first) for easier scanning.