### PR TITLE
fix #27: improve sidebar menu item names and grouping

### DIFF
--- a/internal/core/chart_view.templ
+++ b/internal/core/chart_view.templ
@@ -8,7 +8,7 @@ templ PageChart(p PredictionParams) {
 
 templ ChartContent(p PredictionParams) {
 	<main class="flex-1 flex flex-col">
-		@Header("Chart", ChartControls(p))
+		@Header("Forecast", ChartControls(p))
 		<div class="flex-1 p-6 overflow-auto bg-base-50">
 			<div id="main" style="width: 100%; height: 100%;"></div>
 			<script src="/static/public/echarts.min.js"></script>

--- a/internal/core/chart_view_templ.go
+++ b/internal/core/chart_view_templ.go
@@ -64,7 +64,7 @@ func ChartContent(p PredictionParams) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Header("Chart", ChartControls(p)).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Header("Forecast", ChartControls(p)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/snapshots_table_view.templ
+++ b/internal/core/snapshots_table_view.templ
@@ -15,7 +15,7 @@ templ SnapshotsTableNewRowButton() {
 
 templ SnapshotsTableContent(view *SnapshotsTableView) {
 	<main class="flex-1 flex flex-col overflow-hidden">
-		@Header("Snapshots Table", AccountsFilter(view.AccountTypes), SnapshotsTableNewRowButton())
+		@Header("Balances", AccountsFilter(view.AccountTypes), SnapshotsTableNewRowButton())
 		<div class="flex-1 p-6 bg-base-100 overflow-hidden">
 			<div class="bg-base-100 rounded-lg shadow-sm border border-base-200 h-full flex flex-col overflow-hidden max-w-full">
 				<div class="flex-1 overflow-auto border border-base-300 rounded-lg">

--- a/internal/core/snapshots_table_view_templ.go
+++ b/internal/core/snapshots_table_view_templ.go
@@ -101,7 +101,7 @@ func SnapshotsTableContent(view *SnapshotsTableView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Header("Snapshots Table", AccountsFilter(view.AccountTypes), SnapshotsTableNewRowButton()).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Header("Balances", AccountsFilter(view.AccountTypes), SnapshotsTableNewRowButton()).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/transfers_chart_view.templ
+++ b/internal/core/transfers_chart_view.templ
@@ -6,7 +6,7 @@ templ PageTransfersChart(groupBy TransferChartGroupBy) {
 
 templ TransfersChartContent(groupBy TransferChartGroupBy) {
 	<main class="flex-1 flex flex-col">
-		@Header("Chart", TransfersChartControls(groupBy))
+		@Header("Cashflows", TransfersChartControls(groupBy))
 		<div class="flex-1 p-6 overflow-auto bg-base-50">
 			<div id="transfer-chart" style="width: 100%; height: 100%;"></div>
 			<script src="/static/public/echarts.min.js"></script>

--- a/internal/core/transfers_chart_view_templ.go
+++ b/internal/core/transfers_chart_view_templ.go
@@ -62,7 +62,7 @@ func TransfersChartContent(groupBy TransferChartGroupBy) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Header("Chart", TransfersChartControls(groupBy)).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Header("Cashflows", TransfersChartControls(groupBy)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/transfers_view.templ
+++ b/internal/core/transfers_view.templ
@@ -6,7 +6,7 @@ templ PageTransfers(view *TransfersView) {
 
 templ TransfersContent(view *TransfersView) {
 	<main class="flex-1 flex flex-col">
-		@Header("Transfers")
+		@Header("Transfer Calculator")
 		<div class="flex-1 p-6 overflow-auto bg-base-50">
 			<div class="flex flex-col gap-4">
 				@TransfersForm(view)

--- a/internal/core/transfers_view_templ.go
+++ b/internal/core/transfers_view_templ.go
@@ -62,7 +62,7 @@ func TransfersContent(view *TransfersView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Header("Transfers").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Header("Transfer Calculator").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/view_main.templ
+++ b/internal/core/view_main.templ
@@ -69,18 +69,18 @@ templ SidebarContent(page string) {
 				@NavGroup("Accounts",
 					NavItem("/accounts", IconCashBanknote("w-5 h-5"), "Accounts", page),
 					NavItem("/account-types", IconTag("w-5 h-5"), "Account Types", page),
-					NavItem("/snapshots-table", IconTable("w-5 h-5"), "Snapshots Table", page),
+					NavItem("/snapshots-table", IconTable("w-5 h-5"), "Balances", page),
 				)
 				@NavGroup("Transfers",
 					NavItem("/transfer-templates", IconTransfer("w-5 h-5"), "Transfer Templates", page),
 					NavItem("/transfer-template-categories", IconTag("w-5 h-5"), "Categories", page),
 					NavItem("/budget", IconCashBanknote("w-5 h-5"), "Budget", page),
-					NavItem("/transfers", IconTransfer("w-5 h-5"), "Transfers", page),
-					NavItem("/transfers/chart", IconChartSankey("w-5 h-5"), "Transfers Chart", page),
+					NavItem("/transfers", IconTransfer("w-5 h-5"), "Transfer Calculator", page),
 				)
-				@NavGroup("Charts",
+				@NavGroup("Forecasting",
+					NavItem("/transfers/chart", IconChartSankey("w-5 h-5"), "Cashflows", page),
 					NavItem("/special-dates", IconCalendar("w-5 h-5"), "Special Dates", page),
-					NavItem("/chart", IconTrendingUp("w-5 h-5"), "Chart", page),
+					NavItem("/chart", IconTrendingUp("w-5 h-5"), "Forecast", page),
 				)
 			</ul>
 		</nav>

--- a/internal/core/view_main_templ.go
+++ b/internal/core/view_main_templ.go
@@ -233,7 +233,7 @@ func SidebarContent(page string) templ.Component {
 		templ_7745c5c3_Err = NavGroup("Accounts",
 			NavItem("/accounts", IconCashBanknote("w-5 h-5"), "Accounts", page),
 			NavItem("/account-types", IconTag("w-5 h-5"), "Account Types", page),
-			NavItem("/snapshots-table", IconTable("w-5 h-5"), "Snapshots Table", page),
+			NavItem("/snapshots-table", IconTable("w-5 h-5"), "Balances", page),
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -242,15 +242,15 @@ func SidebarContent(page string) templ.Component {
 			NavItem("/transfer-templates", IconTransfer("w-5 h-5"), "Transfer Templates", page),
 			NavItem("/transfer-template-categories", IconTag("w-5 h-5"), "Categories", page),
 			NavItem("/budget", IconCashBanknote("w-5 h-5"), "Budget", page),
-			NavItem("/transfers", IconTransfer("w-5 h-5"), "Transfers", page),
-			NavItem("/transfers/chart", IconChartSankey("w-5 h-5"), "Transfers Chart", page),
+			NavItem("/transfers", IconTransfer("w-5 h-5"), "Transfer Calculator", page),
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = NavGroup("Charts",
+		templ_7745c5c3_Err = NavGroup("Forecasting",
+			NavItem("/transfers/chart", IconChartSankey("w-5 h-5"), "Cashflows", page),
 			NavItem("/special-dates", IconCalendar("w-5 h-5"), "Special Dates", page),
-			NavItem("/chart", IconTrendingUp("w-5 h-5"), "Chart", page),
+			NavItem("/chart", IconTrendingUp("w-5 h-5"), "Forecast", page),
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err


### PR DESCRIPTION
Rename: Snapshots Table -> Balances, Transfers -> Transfer Calculator, Transfers Chart -> Cashflows, Chart -> Forecast.
Regroup: Charts -> Forecasting, move Cashflows from Transfers to Forecasting.