### PR TITLE
fix #22: use comma thousands separator in dashboard chart tooltip, ad…

### DIFF
--- a/internal/core/budget_view.templ
+++ b/internal/core/budget_view.templ
@@ -51,6 +51,7 @@ templ BudgetContent(view *BudgetView) {
                     </div>
                 </div>
 			</div>
+			@ItemsTooltipScript()
 			<script src="/static/public/echarts.min.js"></script>
             <script src="/static/public/chart-transfers.js"></script>
 			@templ.JSONScript("budget-chart-data", view.ChartData)
@@ -60,7 +61,7 @@ templ BudgetContent(view *BudgetView) {
 }
 
 templ BudgetCategoryTable(categories []BudgetCategoryGroup, grandTotal float64) {
-	<div class="overflow-x-auto">
+	<div>
 		<table class="table table-zebra w-full">
 			<thead>
 				<tr>
@@ -71,14 +72,22 @@ templ BudgetCategoryTable(categories []BudgetCategoryGroup, grandTotal float64) 
 			</thead>
 			<tbody>
 				for _, cat := range categories {
-					<tr>
+					<tr class="group relative">
 						<td>
 							<div class="flex items-center gap-2">
 								if cat.Category.Color != nil {
 									<div class="w-3 h-3 rounded-full" style={ fmt.Sprintf("background-color: %s", *cat.Category.Color) }></div>
 								}
 								<span>{ cat.Category.Name }</span>
+								<span class="text-sm text-base-content/60">
+									({ fmt.Sprintf("%d", len(cat.Items)) })
+								</span>
 							</div>
+							@ItemsTooltip() {
+								for _, item := range cat.Items {
+									@ItemsTooltipRow(item.Name, ui.FormatWithThousands(item.Amount))
+								}
+							}
 						</td>
 						<td class="text-right font-mono">{ ui.FormatWithThousands(cat.Total) }</td>
 						<td class="text-right">

--- a/internal/core/budget_view_templ.go
+++ b/internal/core/budget_view_templ.go
@@ -111,7 +111,15 @@ func BudgetContent(view *BudgetView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"mt-6\"><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Transfers</h2><div id=\"transfer-chart\" x-filter=\"?group_by=account_type\" style=\"width: 100%; height: 30vh\"></div></div></div></div><script src=\"/static/public/echarts.min.js\"></script><script src=\"/static/public/chart-transfers.js\"></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"mt-6\"><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Transfers</h2><div id=\"transfer-chart\" x-filter=\"?group_by=account_type\" style=\"width: 100%; height: 30vh\"></div></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = ItemsTooltipScript().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<script src=\"/static/public/echarts.min.js\"></script><script src=\"/static/public/chart-transfers.js\"></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -123,7 +131,7 @@ func BudgetContent(view *BudgetView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -152,94 +160,135 @@ func BudgetCategoryTable(categories []BudgetCategoryGroup, grandTotal float64) t
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"overflow-x-auto\"><table class=\"table table-zebra w-full\"><thead><tr><th>Category</th><th class=\"text-right\">Monthly</th><th class=\"text-right\">%</th></tr></thead> <tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div><table class=\"table table-zebra w-full\"><thead><tr><th>Category</th><th class=\"text-right\">Monthly</th><th class=\"text-right\">%</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, cat := range categories {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<tr><td><div class=\"flex items-center gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<tr class=\"group relative\"><td><div class=\"flex items-center gap-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if cat.Category.Color != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"w-3 h-3 rounded-full\" style=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"w-3 h-3 rounded-full\" style=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fmt.Sprintf("background-color: %s", *cat.Category.Color))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 78, Col: 107}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 79, Col: 107}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Category.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 80, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 81, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span></div></td><td class=\"text-right font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</span> <span class=\"text-sm text-base-content/60\">(")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(cat.Total))
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", len(cat.Items)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 83, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 83, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</td><td class=\"text-right\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, ")</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				for _, item := range cat.Items {
+					templ_7745c5c3_Err = ItemsTooltipRow(item.Name, ui.FormatWithThousands(item.Amount)).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = ItemsTooltip().Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</td><td class=\"text-right font-mono\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(cat.Total))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 92, Col: 74}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</td><td class=\"text-right\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if grandTotal > 0 {
-				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.1f%%", (cat.Total/grandTotal)*100))
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.1f%%", (cat.Total/grandTotal)*100))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 86, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 95, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<tr class=\"font-bold border-t-2 border-base-300\"><td>Total</td><td class=\"text-right font-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<tr class=\"font-bold border-t-2 border-base-300\"><td>Total</td><td class=\"text-right font-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(grandTotal))
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(grandTotal))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 93, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 102, Col: 74}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</td><td class=\"text-right\">100%</td></tr></tbody></table></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</td><td class=\"text-right\">100%</td></tr></tbody></table></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -263,112 +312,112 @@ func BudgetCategoryDetails(cat BudgetCategoryGroup) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div class=\"collapse collapse-arrow bg-base-200 mb-2\"><input type=\"checkbox\"><div class=\"collapse-title font-medium\"><div class=\"flex justify-between items-center pr-4\"><div class=\"flex items-center gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div class=\"collapse collapse-arrow bg-base-200 mb-2\"><input type=\"checkbox\"><div class=\"collapse-title font-medium\"><div class=\"flex justify-between items-center pr-4\"><div class=\"flex items-center gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cat.Category.Color != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"w-3 h-3 rounded-full\" style=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"w-3 h-3 rounded-full\" style=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fmt.Sprintf("background-color: %s", *cat.Category.Color))
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fmt.Sprintf("background-color: %s", *cat.Category.Color))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 108, Col: 104}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 117, Col: 104}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\"></div>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Category.Name)
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Category.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 110, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 119, Col: 30}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span></div><span class=\"font-mono\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(cat.Total))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 112, Col: 63}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</span></div><span class=\"font-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</span></div></div><div class=\"collapse-content\"><table class=\"table table-sm w-full\"><thead><tr><th>Name</th><th class=\"text-right\">Amount</th><th>Type</th></tr></thead> <tbody>")
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(cat.Total))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 121, Col: 63}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</span></div></div><div class=\"collapse-content\"><table class=\"table table-sm w-full\"><thead><tr><th>Name</th><th class=\"text-right\">Amount</th><th>Type</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, item := range cat.Items {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<tr><td>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<tr><td>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(item.Name)
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(item.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 127, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 136, Col: 22}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</td><td class=\"text-right font-mono\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var14 string
-			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(item.Amount))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 128, Col: 77}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</td><td class=\"text-right font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</td><td>")
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(ui.FormatWithThousands(item.Amount))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/budget_view.templ`, Line: 137, Col: 77}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</td><td>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if item.Source == "interest" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<span class=\"badge badge-sm badge-info\">Interest</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"badge badge-sm badge-info\">Interest</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<span class=\"badge badge-sm badge-ghost\">Transfer</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<span class=\"badge badge-sm badge-ghost\">Transfer</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</tbody></table></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</tbody></table></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -392,12 +441,12 @@ func BudgetChartScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<script type=\"text/javascript\">\n\t\t(function() {\n\t\t\tvar chartDom = document.getElementById('budget-pie-chart');\n\t\t\tif (!chartDom) return;\n\t\t\tvar myChart = echarts.init(chartDom);\n\t\t\tvar data = JSON.parse(document.getElementById('budget-chart-data').textContent);\n\t\t\tvar option = {\n\t\t\t\ttooltip: {\n\t\t\t\t\ttrigger: 'item',\n\t\t\t\t\tformatter: '{b}: {c} ({d}%)'\n\t\t\t\t},\n\t\t\t\tseries: [{\n\t\t\t\t\tname: 'Monthly Budget',\n\t\t\t\t\ttype: 'pie',\n\t\t\t\t\tradius: ['40%', '70%'],\n\t\t\t\t\tavoidLabelOverlap: true,\n\t\t\t\t\titemStyle: {\n\t\t\t\t\t\tborderRadius: 6,\n\t\t\t\t\t\tborderColor: '#fff',\n\t\t\t\t\t\tborderWidth: 2\n\t\t\t\t\t},\n\t\t\t\t\tlabel: {\n\t\t\t\t\t\tshow: true,\n\t\t\t\t\t\tformatter: '{b}\\n{d}%'\n\t\t\t\t\t},\n\t\t\t\t\tdata: data.map(function(item) {\n\t\t\t\t\t\treturn {\n\t\t\t\t\t\t\tname: item.name,\n\t\t\t\t\t\t\tvalue: item.value,\n\t\t\t\t\t\t\titemStyle: { color: item.color }\n\t\t\t\t\t\t};\n\t\t\t\t\t})\n\t\t\t\t}]\n\t\t\t};\n\t\t\tmyChart.setOption(option);\n\t\t\twindow.addEventListener('resize', function() {\n\t\t\t\tmyChart.resize();\n\t\t\t});\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<script type=\"text/javascript\">\n\t\t(function() {\n\t\t\tvar chartDom = document.getElementById('budget-pie-chart');\n\t\t\tif (!chartDom) return;\n\t\t\tvar myChart = echarts.init(chartDom);\n\t\t\tvar data = JSON.parse(document.getElementById('budget-chart-data').textContent);\n\t\t\tvar option = {\n\t\t\t\ttooltip: {\n\t\t\t\t\ttrigger: 'item',\n\t\t\t\t\tformatter: '{b}: {c} ({d}%)'\n\t\t\t\t},\n\t\t\t\tseries: [{\n\t\t\t\t\tname: 'Monthly Budget',\n\t\t\t\t\ttype: 'pie',\n\t\t\t\t\tradius: ['40%', '70%'],\n\t\t\t\t\tavoidLabelOverlap: true,\n\t\t\t\t\titemStyle: {\n\t\t\t\t\t\tborderRadius: 6,\n\t\t\t\t\t\tborderColor: '#fff',\n\t\t\t\t\t\tborderWidth: 2\n\t\t\t\t\t},\n\t\t\t\t\tlabel: {\n\t\t\t\t\t\tshow: true,\n\t\t\t\t\t\tformatter: '{b}\\n{d}%'\n\t\t\t\t\t},\n\t\t\t\t\tdata: data.map(function(item) {\n\t\t\t\t\t\treturn {\n\t\t\t\t\t\t\tname: item.name,\n\t\t\t\t\t\t\tvalue: item.value,\n\t\t\t\t\t\t\titemStyle: { color: item.color }\n\t\t\t\t\t\t};\n\t\t\t\t\t})\n\t\t\t\t}]\n\t\t\t};\n\t\t\tmyChart.setOption(option);\n\t\t\twindow.addEventListener('resize', function() {\n\t\t\t\tmyChart.resize();\n\t\t\t});\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/dashboard_view.templ
+++ b/internal/core/dashboard_view.templ
@@ -43,7 +43,7 @@ templ DashboardMainContent(view *DashboardView) {
 				<div class="card bg-base-100 shadow-sm border border-base-300">
 					<div class="card-body">
 						<h2 class="card-title">Account Balances</h2>
-						<div class="overflow-x-auto">
+						<div>
 							<table class="table table-zebra w-full">
 								<thead>
 									<tr>
@@ -53,7 +53,7 @@ templ DashboardMainContent(view *DashboardView) {
 								</thead>
 								<tbody>
 									for _, group := range view.AccountTypeGroups {
-										<tr>
+										<tr class="group relative">
 											<td>
 												<div class="flex items-center gap-2">
 													<div class="w-3 h-3 rounded-full" style={ fmt.Sprintf("background-color: %s", group.AccountType.Color) }></div>
@@ -62,6 +62,15 @@ templ DashboardMainContent(view *DashboardView) {
 														({ fmt.Sprintf("%d", len(group.Accounts)) })
 													</span>
 												</div>
+												@ItemsTooltip() {
+													for _, acc := range group.Accounts {
+														if acc.LastSnapshot != nil {
+															@ItemsTooltipRow(acc.Name, ui.FormatWithThousands(acc.LastSnapshot.Balance.Mean()))
+														} else {
+															@ItemsTooltipRow(acc.Name, "—")
+														}
+													}
+												}
 											</td>
 											<td class="text-right">
 												@BalanceBadge(group.TotalBalance, true, "")
@@ -80,6 +89,7 @@ templ DashboardMainContent(view *DashboardView) {
 					</div>
 				</div>
 			</div>
+			@ItemsTooltipScript()
 			<script src="/static/public/echarts.min.js"></script>
 			@templ.JSONScript("dashboard-budget-data", view.Budget.ChartData)
 			@templ.JSONScript("dashboard-accounts-data", view.AccountChartData)

--- a/internal/core/dashboard_view_templ.go
+++ b/internal/core/dashboard_view_templ.go
@@ -99,12 +99,12 @@ func DashboardMainContent(view *DashboardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Budget Breakdown</h2><div id=\"dashboard-budget-chart\" style=\"width: 100%; height: 400px;\"></div></div></div></div><div class=\"grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6\"><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Accounts by Type</h2><div id=\"dashboard-accounts-chart\" style=\"width: 100%; height: 400px;\"></div></div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Account Balances</h2><div class=\"overflow-x-auto\"><table class=\"table table-zebra w-full\"><thead><tr><th>Account Type</th><th class=\"text-right\">Balance</th></tr></thead> <tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Budget Breakdown</h2><div id=\"dashboard-budget-chart\" style=\"width: 100%; height: 400px;\"></div></div></div></div><div class=\"grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6\"><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Accounts by Type</h2><div id=\"dashboard-accounts-chart\" style=\"width: 100%; height: 400px;\"></div></div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title\">Account Balances</h2><div><table class=\"table table-zebra w-full\"><thead><tr><th>Account Type</th><th class=\"text-right\">Balance</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, group := range view.AccountTypeGroups {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<tr><td><div class=\"flex items-center gap-2\"><div class=\"w-3 h-3 rounded-full\" style=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<tr class=\"group relative\"><td><div class=\"flex items-center gap-2\"><div class=\"w-3 h-3 rounded-full\" style=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -143,7 +143,42 @@ func DashboardMainContent(view *DashboardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, ")</span></div></td><td class=\"text-right\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, ")</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				for _, acc := range group.Accounts {
+					if acc.LastSnapshot != nil {
+						templ_7745c5c3_Err = ItemsTooltipRow(acc.Name, ui.FormatWithThousands(acc.LastSnapshot.Balance.Mean())).Render(ctx, templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					} else {
+						templ_7745c5c3_Err = ItemsTooltipRow(acc.Name, "—").Render(ctx, templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = ItemsTooltip().Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</td><td class=\"text-right\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -151,12 +186,12 @@ func DashboardMainContent(view *DashboardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<tr class=\"font-bold border-t-2 border-base-300\"><td>Net Worth</td><td class=\"text-right\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<tr class=\"font-bold border-t-2 border-base-300\"><td>Net Worth</td><td class=\"text-right\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -164,7 +199,15 @@ func DashboardMainContent(view *DashboardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</td></tr></tbody></table></div></div></div></div><script src=\"/static/public/echarts.min.js\"></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</td></tr></tbody></table></div></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = ItemsTooltipScript().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<script src=\"/static/public/echarts.min.js\"></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -180,7 +223,7 @@ func DashboardMainContent(view *DashboardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -204,12 +247,12 @@ func DashboardChartsScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<script type=\"text/javascript\">\n\t\t(function() {\n\t\t\tfunction formatThousands(val) {\n\t\t\t\tvar n = Math.round(val);\n\t\t\t\tvar neg = n < 0;\n\t\t\t\tvar s = Math.abs(n).toString();\n\t\t\t\tvar pre = s.length % 3 || 3;\n\t\t\t\tvar out = s.slice(0, pre);\n\t\t\t\tfor (var i = pre; i < s.length; i += 3) {\n\t\t\t\t\tout += ',' + s.slice(i, i + 3);\n\t\t\t\t}\n\t\t\t\treturn neg ? '-' + out : out;\n\t\t\t}\n\n\t\t\t// Budget donut chart\n\t\t\tvar budgetDom = document.getElementById('dashboard-budget-chart');\n\t\t\tif (budgetDom) {\n\t\t\t\tvar budgetChart = echarts.init(budgetDom);\n\t\t\t\tvar budgetData = JSON.parse(document.getElementById('dashboard-budget-data').textContent);\n\t\t\t\tbudgetChart.setOption({\n\t\t\t\t\ttooltip: {\n\t\t\t\t\t\ttrigger: 'item',\n\t\t\t\t\t\tformatter: '{b}: {c} ({d}%)'\n\t\t\t\t\t},\n\t\t\t\t\tseries: [{\n\t\t\t\t\t\tname: 'Monthly Budget',\n\t\t\t\t\t\ttype: 'pie',\n\t\t\t\t\t\tradius: ['40%', '70%'],\n\t\t\t\t\t\tavoidLabelOverlap: true,\n\t\t\t\t\t\titemStyle: {\n\t\t\t\t\t\t\tborderRadius: 6,\n\t\t\t\t\t\t\tborderColor: '#fff',\n\t\t\t\t\t\t\tborderWidth: 2\n\t\t\t\t\t\t},\n\t\t\t\t\t\tlabel: {\n\t\t\t\t\t\t\tshow: true,\n\t\t\t\t\t\t\tformatter: '{b}\\n{d}%'\n\t\t\t\t\t\t},\n\t\t\t\t\t\tdata: budgetData.map(function(item) {\n\t\t\t\t\t\t\treturn {\n\t\t\t\t\t\t\t\tname: item.name,\n\t\t\t\t\t\t\t\tvalue: item.value,\n\t\t\t\t\t\t\t\titemStyle: { color: item.color }\n\t\t\t\t\t\t\t};\n\t\t\t\t\t\t})\n\t\t\t\t\t}]\n\t\t\t\t});\n\t\t\t\twindow.addEventListener('resize', function() { budgetChart.resize(); });\n\t\t\t}\n\n\t\t\t// Accounts stacked bar chart\n\t\t\tvar accountsDom = document.getElementById('dashboard-accounts-chart');\n\t\t\tif (accountsDom) {\n\t\t\t\tvar accountsChart = echarts.init(accountsDom);\n\t\t\t\tvar accountsData = JSON.parse(document.getElementById('dashboard-accounts-data').textContent);\n\n\t\t\t\tfunction hexToHSL(hex) {\n\t\t\t\t\tvar r = parseInt(hex.slice(1, 3), 16) / 255;\n\t\t\t\t\tvar g = parseInt(hex.slice(3, 5), 16) / 255;\n\t\t\t\t\tvar b = parseInt(hex.slice(5, 7), 16) / 255;\n\t\t\t\t\tvar max = Math.max(r, g, b), min = Math.min(r, g, b);\n\t\t\t\t\tvar h, s, l = (max + min) / 2;\n\t\t\t\t\tif (max === min) { h = s = 0; }\n\t\t\t\t\telse {\n\t\t\t\t\t\tvar d = max - min;\n\t\t\t\t\t\ts = l > 0.5 ? d / (2 - max - min) : d / (max + min);\n\t\t\t\t\t\tif (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;\n\t\t\t\t\t\telse if (max === g) h = ((b - r) / d + 2) / 6;\n\t\t\t\t\t\telse h = ((r - g) / d + 4) / 6;\n\t\t\t\t\t}\n\t\t\t\t\treturn [h * 360, s * 100, l * 100];\n\t\t\t\t}\n\n\t\t\t\tfunction hslToHex(h, s, l) {\n\t\t\t\t\ts /= 100; l /= 100;\n\t\t\t\t\tvar c = (1 - Math.abs(2 * l - 1)) * s;\n\t\t\t\t\tvar x = c * (1 - Math.abs((h / 60) % 2 - 1));\n\t\t\t\t\tvar m = l - c / 2;\n\t\t\t\t\tvar r, g, b;\n\t\t\t\t\tif (h < 60) { r = c; g = x; b = 0; }\n\t\t\t\t\telse if (h < 120) { r = x; g = c; b = 0; }\n\t\t\t\t\telse if (h < 180) { r = 0; g = c; b = x; }\n\t\t\t\t\telse if (h < 240) { r = 0; g = x; b = c; }\n\t\t\t\t\telse if (h < 300) { r = x; g = 0; b = c; }\n\t\t\t\t\telse { r = c; g = 0; b = x; }\n\t\t\t\t\treturn '#' + [r + m, g + m, b + m].map(function(v) {\n\t\t\t\t\t\treturn Math.round(v * 255).toString(16).padStart(2, '0');\n\t\t\t\t\t}).join('');\n\t\t\t\t}\n\n\t\t\t\tfunction shadeColor(hex, index, total) {\n\t\t\t\t\tvar hsl = hexToHSL(hex);\n\t\t\t\t\tif (total <= 1) return hex;\n\t\t\t\t\tvar range = 30;\n\t\t\t\t\tvar offset = -range / 2 + (range / (total - 1)) * index;\n\t\t\t\t\tvar newL = Math.max(15, Math.min(85, hsl[2] + offset));\n\t\t\t\t\treturn hslToHex(hsl[0], hsl[1], newL);\n\t\t\t\t}\n\n\t\t\t\tvar typeNames = accountsData.map(function(t) { return t.name; });\n\n\t\t\t\tvar series = [];\n\t\t\t\taccountsData.forEach(function(typeEntry) {\n\t\t\t\t\tvar n = typeEntry.accounts.length;\n\t\t\t\t\ttypeEntry.accounts.forEach(function(acc, i) {\n\t\t\t\t\t\tvar data = typeNames.map(function(tn) {\n\t\t\t\t\t\t\treturn tn === typeEntry.name ? acc.balance : 0;\n\t\t\t\t\t\t});\n\t\t\t\t\t\tseries.push({\n\t\t\t\t\t\t\tname: acc.name,\n\t\t\t\t\t\t\ttype: 'bar',\n\t\t\t\t\t\t\tstack: 'total',\n\t\t\t\t\t\t\temphasis: { focus: 'series' },\n\t\t\t\t\t\t\titemStyle: { color: shadeColor(typeEntry.color, i, n) },\n\t\t\t\t\t\t\tdata: data\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\taccountsChart.setOption({\n\t\t\t\t\ttooltip: {\n\t\t\t\t\t\ttrigger: 'axis',\n\t\t\t\t\t\taxisPointer: { type: 'shadow' },\n\t\t\t\t\t\tformatter: function(params) {\n\t\t\t\t\t\t\tvar items = params.filter(function(p) { return p.value !== 0; });\n\t\t\t\t\t\t\tif (items.length === 0) return '';\n\t\t\t\t\t\t\tvar header = items[0].axisValue;\n\t\t\t\t\t\t\tvar total = items.reduce(function(sum, p) { return sum + p.value; }, 0);\n\t\t\t\t\t\t\tvar lines = items.map(function(p) {\n\t\t\t\t\t\t\t\treturn '<div style=\"display:flex;justify-content:space-between;gap:16px\">' +\n\t\t\t\t\t\t\t\t\t'<span>' + p.marker + ' ' + p.seriesName + '</span>' +\n\t\t\t\t\t\t\t\t\t'<span style=\"font-weight:500\">' + formatThousands(p.value) + '</span></div>';\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tvar totalLine = '<div style=\"display:flex;justify-content:space-between;gap:16px;border-top:1px solid #ccc;margin-top:4px;padding-top:4px\">' +\n\t\t\t\t\t\t\t\t'<span>Total</span><span style=\"font-weight:700\">' + formatThousands(total) + '</span></div>';\n\t\t\t\t\t\t\treturn header + '<br/>' + lines.join('') + totalLine;\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\tgrid: {\n\t\t\t\t\t\tleft: '3%',\n\t\t\t\t\t\tright: '4%',\n\t\t\t\t\t\tbottom: '3%',\n\t\t\t\t\t\tcontainLabel: true\n\t\t\t\t\t},\n\t\t\t\t\txAxis: {\n\t\t\t\t\t\ttype: 'category',\n\t\t\t\t\t\tdata: typeNames,\n\t\t\t\t\t\taxisLabel: {\n\t\t\t\t\t\t\trotate: 30,\n\t\t\t\t\t\t\toverflow: 'truncate'\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\tyAxis: {\n\t\t\t\t\t\ttype: 'value'\n\t\t\t\t\t},\n\t\t\t\t\tseries: series\n\t\t\t\t});\n\t\t\t\twindow.addEventListener('resize', function() { accountsChart.resize(); });\n\t\t\t}\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<script type=\"text/javascript\">\n\t\t(function() {\n\t\t\tfunction formatThousands(val) {\n\t\t\t\tvar n = Math.round(val);\n\t\t\t\tvar neg = n < 0;\n\t\t\t\tvar s = Math.abs(n).toString();\n\t\t\t\tvar pre = s.length % 3 || 3;\n\t\t\t\tvar out = s.slice(0, pre);\n\t\t\t\tfor (var i = pre; i < s.length; i += 3) {\n\t\t\t\t\tout += ',' + s.slice(i, i + 3);\n\t\t\t\t}\n\t\t\t\treturn neg ? '-' + out : out;\n\t\t\t}\n\n\t\t\t// Budget donut chart\n\t\t\tvar budgetDom = document.getElementById('dashboard-budget-chart');\n\t\t\tif (budgetDom) {\n\t\t\t\tvar budgetChart = echarts.init(budgetDom);\n\t\t\t\tvar budgetData = JSON.parse(document.getElementById('dashboard-budget-data').textContent);\n\t\t\t\tbudgetChart.setOption({\n\t\t\t\t\ttooltip: {\n\t\t\t\t\t\ttrigger: 'item',\n\t\t\t\t\t\tformatter: '{b}: {c} ({d}%)'\n\t\t\t\t\t},\n\t\t\t\t\tseries: [{\n\t\t\t\t\t\tname: 'Monthly Budget',\n\t\t\t\t\t\ttype: 'pie',\n\t\t\t\t\t\tradius: ['40%', '70%'],\n\t\t\t\t\t\tavoidLabelOverlap: true,\n\t\t\t\t\t\titemStyle: {\n\t\t\t\t\t\t\tborderRadius: 6,\n\t\t\t\t\t\t\tborderColor: '#fff',\n\t\t\t\t\t\t\tborderWidth: 2\n\t\t\t\t\t\t},\n\t\t\t\t\t\tlabel: {\n\t\t\t\t\t\t\tshow: true,\n\t\t\t\t\t\t\tformatter: '{b}\\n{d}%'\n\t\t\t\t\t\t},\n\t\t\t\t\t\tdata: budgetData.map(function(item) {\n\t\t\t\t\t\t\treturn {\n\t\t\t\t\t\t\t\tname: item.name,\n\t\t\t\t\t\t\t\tvalue: item.value,\n\t\t\t\t\t\t\t\titemStyle: { color: item.color }\n\t\t\t\t\t\t\t};\n\t\t\t\t\t\t})\n\t\t\t\t\t}]\n\t\t\t\t});\n\t\t\t\twindow.addEventListener('resize', function() { budgetChart.resize(); });\n\t\t\t}\n\n\t\t\t// Accounts stacked bar chart\n\t\t\tvar accountsDom = document.getElementById('dashboard-accounts-chart');\n\t\t\tif (accountsDom) {\n\t\t\t\tvar accountsChart = echarts.init(accountsDom);\n\t\t\t\tvar accountsData = JSON.parse(document.getElementById('dashboard-accounts-data').textContent);\n\n\t\t\t\tfunction hexToHSL(hex) {\n\t\t\t\t\tvar r = parseInt(hex.slice(1, 3), 16) / 255;\n\t\t\t\t\tvar g = parseInt(hex.slice(3, 5), 16) / 255;\n\t\t\t\t\tvar b = parseInt(hex.slice(5, 7), 16) / 255;\n\t\t\t\t\tvar max = Math.max(r, g, b), min = Math.min(r, g, b);\n\t\t\t\t\tvar h, s, l = (max + min) / 2;\n\t\t\t\t\tif (max === min) { h = s = 0; }\n\t\t\t\t\telse {\n\t\t\t\t\t\tvar d = max - min;\n\t\t\t\t\t\ts = l > 0.5 ? d / (2 - max - min) : d / (max + min);\n\t\t\t\t\t\tif (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;\n\t\t\t\t\t\telse if (max === g) h = ((b - r) / d + 2) / 6;\n\t\t\t\t\t\telse h = ((r - g) / d + 4) / 6;\n\t\t\t\t\t}\n\t\t\t\t\treturn [h * 360, s * 100, l * 100];\n\t\t\t\t}\n\n\t\t\t\tfunction hslToHex(h, s, l) {\n\t\t\t\t\ts /= 100; l /= 100;\n\t\t\t\t\tvar c = (1 - Math.abs(2 * l - 1)) * s;\n\t\t\t\t\tvar x = c * (1 - Math.abs((h / 60) % 2 - 1));\n\t\t\t\t\tvar m = l - c / 2;\n\t\t\t\t\tvar r, g, b;\n\t\t\t\t\tif (h < 60) { r = c; g = x; b = 0; }\n\t\t\t\t\telse if (h < 120) { r = x; g = c; b = 0; }\n\t\t\t\t\telse if (h < 180) { r = 0; g = c; b = x; }\n\t\t\t\t\telse if (h < 240) { r = 0; g = x; b = c; }\n\t\t\t\t\telse if (h < 300) { r = x; g = 0; b = c; }\n\t\t\t\t\telse { r = c; g = 0; b = x; }\n\t\t\t\t\treturn '#' + [r + m, g + m, b + m].map(function(v) {\n\t\t\t\t\t\treturn Math.round(v * 255).toString(16).padStart(2, '0');\n\t\t\t\t\t}).join('');\n\t\t\t\t}\n\n\t\t\t\tfunction shadeColor(hex, index, total) {\n\t\t\t\t\tvar hsl = hexToHSL(hex);\n\t\t\t\t\tif (total <= 1) return hex;\n\t\t\t\t\tvar range = 30;\n\t\t\t\t\tvar offset = -range / 2 + (range / (total - 1)) * index;\n\t\t\t\t\tvar newL = Math.max(15, Math.min(85, hsl[2] + offset));\n\t\t\t\t\treturn hslToHex(hsl[0], hsl[1], newL);\n\t\t\t\t}\n\n\t\t\t\tvar typeNames = accountsData.map(function(t) { return t.name; });\n\n\t\t\t\tvar series = [];\n\t\t\t\taccountsData.forEach(function(typeEntry) {\n\t\t\t\t\tvar n = typeEntry.accounts.length;\n\t\t\t\t\ttypeEntry.accounts.forEach(function(acc, i) {\n\t\t\t\t\t\tvar data = typeNames.map(function(tn) {\n\t\t\t\t\t\t\treturn tn === typeEntry.name ? acc.balance : 0;\n\t\t\t\t\t\t});\n\t\t\t\t\t\tseries.push({\n\t\t\t\t\t\t\tname: acc.name,\n\t\t\t\t\t\t\ttype: 'bar',\n\t\t\t\t\t\t\tstack: 'total',\n\t\t\t\t\t\t\temphasis: { focus: 'series' },\n\t\t\t\t\t\t\titemStyle: { color: shadeColor(typeEntry.color, i, n) },\n\t\t\t\t\t\t\tdata: data\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\taccountsChart.setOption({\n\t\t\t\t\ttooltip: {\n\t\t\t\t\t\ttrigger: 'axis',\n\t\t\t\t\t\taxisPointer: { type: 'shadow' },\n\t\t\t\t\t\tformatter: function(params) {\n\t\t\t\t\t\t\tvar items = params.filter(function(p) { return p.value !== 0; });\n\t\t\t\t\t\t\tif (items.length === 0) return '';\n\t\t\t\t\t\t\tvar header = items[0].axisValue;\n\t\t\t\t\t\t\tvar total = items.reduce(function(sum, p) { return sum + p.value; }, 0);\n\t\t\t\t\t\t\tvar lines = items.map(function(p) {\n\t\t\t\t\t\t\t\treturn '<div style=\"display:flex;justify-content:space-between;gap:16px\">' +\n\t\t\t\t\t\t\t\t\t'<span>' + p.marker + ' ' + p.seriesName + '</span>' +\n\t\t\t\t\t\t\t\t\t'<span style=\"font-weight:500\">' + formatThousands(p.value) + '</span></div>';\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tvar totalLine = '<div style=\"display:flex;justify-content:space-between;gap:16px;border-top:1px solid #ccc;margin-top:4px;padding-top:4px\">' +\n\t\t\t\t\t\t\t\t'<span>Total</span><span style=\"font-weight:700\">' + formatThousands(total) + '</span></div>';\n\t\t\t\t\t\t\treturn header + '<br/>' + lines.join('') + totalLine;\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\tgrid: {\n\t\t\t\t\t\tleft: '3%',\n\t\t\t\t\t\tright: '4%',\n\t\t\t\t\t\tbottom: '3%',\n\t\t\t\t\t\tcontainLabel: true\n\t\t\t\t\t},\n\t\t\t\t\txAxis: {\n\t\t\t\t\t\ttype: 'category',\n\t\t\t\t\t\tdata: typeNames,\n\t\t\t\t\t\taxisLabel: {\n\t\t\t\t\t\t\trotate: 30,\n\t\t\t\t\t\t\toverflow: 'truncate'\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\tyAxis: {\n\t\t\t\t\t\ttype: 'value'\n\t\t\t\t\t},\n\t\t\t\t\tseries: series\n\t\t\t\t});\n\t\t\t\twindow.addEventListener('resize', function() { accountsChart.resize(); });\n\t\t\t}\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/core/view_common.templ
+++ b/internal/core/view_common.templ
@@ -43,6 +43,42 @@ templ BalanceBadge(val float64, coloring bool, class string) {
 	>{ ui.FormatWithThousands(val) }</span>
 }
 
+templ ItemsTooltip() {
+	<div class="hidden group-hover:block fixed z-50 bg-base-100 border border-base-300 rounded-lg shadow-lg p-3 min-w-[250px]" data-tooltip>
+		{ children... }
+	</div>
+}
+
+templ ItemsTooltipScript() {
+	<script type="text/javascript">
+		(function() {
+			document.addEventListener('mouseover', function(e) {
+				var row = e.target.closest('.group');
+				if (!row) return;
+				var tip = row.querySelector('[data-tooltip]');
+				if (!tip) return;
+				var rect = row.getBoundingClientRect();
+				var spaceBelow = window.innerHeight - rect.bottom;
+				tip.style.left = rect.left + 'px';
+				if (spaceBelow < tip.scrollHeight + 8) {
+					tip.style.bottom = (window.innerHeight - rect.top + 4) + 'px';
+					tip.style.top = 'auto';
+				} else {
+					tip.style.top = (rect.bottom + 4) + 'px';
+					tip.style.bottom = 'auto';
+				}
+			});
+		})();
+	</script>
+}
+
+templ ItemsTooltipRow(name string, value string) {
+	<div class="flex justify-between gap-4 py-0.5">
+		<span class="text-sm">{ name }</span>
+		<span class="text-sm font-mono font-medium">{ value }</span>
+	</div>
+}
+
 templ NoDataImg() {
 	<img src="/static/public/empty.png" class="w-12 h-12 text-base-content/30" />
 }

--- a/internal/core/view_common_templ.go
+++ b/internal/core/view_common_templ.go
@@ -196,7 +196,7 @@ func BalanceBadge(val float64, coloring bool, class string) templ.Component {
 	})
 }
 
-func NoDataImg() templ.Component {
+func ItemsTooltip() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -217,7 +217,128 @@ func NoDataImg() templ.Component {
 			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<img src=\"/static/public/empty.png\" class=\"w-12 h-12 text-base-content/30\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"hidden group-hover:block fixed z-50 bg-base-100 border border-base-300 rounded-lg shadow-lg p-3 min-w-[250px]\" data-tooltip>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ_7745c5c3_Var10.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func ItemsTooltipScript() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<script type=\"text/javascript\">\n\t\t(function() {\n\t\t\tdocument.addEventListener('mouseover', function(e) {\n\t\t\t\tvar row = e.target.closest('.group');\n\t\t\t\tif (!row) return;\n\t\t\t\tvar tip = row.querySelector('[data-tooltip]');\n\t\t\t\tif (!tip) return;\n\t\t\t\tvar rect = row.getBoundingClientRect();\n\t\t\t\tvar spaceBelow = window.innerHeight - rect.bottom;\n\t\t\t\ttip.style.left = rect.left + 'px';\n\t\t\t\tif (spaceBelow < tip.scrollHeight + 8) {\n\t\t\t\t\ttip.style.bottom = (window.innerHeight - rect.top + 4) + 'px';\n\t\t\t\t\ttip.style.top = 'auto';\n\t\t\t\t} else {\n\t\t\t\t\ttip.style.top = (rect.bottom + 4) + 'px';\n\t\t\t\t\ttip.style.bottom = 'auto';\n\t\t\t\t}\n\t\t\t});\n\t\t})();\n\t</script>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func ItemsTooltipRow(name string, value string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"flex justify-between gap-4 py-0.5\"><span class=\"text-sm\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/view_common.templ`, Line: 77, Col: 30}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span> <span class=\"text-sm font-mono font-medium\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/core/view_common.templ`, Line: 78, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func NoDataImg() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<img src=\"/static/public/empty.png\" class=\"w-12 h-12 text-base-content/30\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
…d total row

The accounts-by-type chart tooltip was using toLocaleString() which produced space-separated numbers. Now uses a JS formatThousands helper matching the Go FormatWithThousands format. Also adds a total row and right-aligns values.