### PR TITLE
Add simple expression calculator for amount fields (issue #40)

### DIFF
--- a/internal/core/transfers.go
+++ b/internal/core/transfers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SimonSchneider/goslu/srvu"
 	"github.com/SimonSchneider/goslu/static/shttp"
 	"github.com/SimonSchneider/pefigo/internal/finance"
+	"github.com/SimonSchneider/pefigo/internal/ui"
 	"github.com/SimonSchneider/pefigo/internal/uncertain"
 )
 
@@ -67,7 +68,7 @@ func TransfersPage(db *sql.DB) http.Handler {
 			if t.EndDate == nil || t.EndDate.After(inp.day) {
 				if t.StartDate.Before(inp.day) && t.Recurrence.Matches(inp.day) {
 					if t.AmountType == "fixed" && t.AmountFixed.Distribution != uncertain.DistFixed {
-						amount, err := shttp.ParseFloat(r.FormValue("amount_" + t.ID))
+						amount, err := ui.ParseAmount(r.FormValue("amount_" + t.ID))
 						if err == nil {
 							view.transfersReady = true
 						}

--- a/internal/ui/amount.go
+++ b/internal/ui/amount.go
@@ -1,0 +1,281 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// ParseAmount parses a string as either a single number or a simple arithmetic
+// expression (+, -, *, /, parentheses). Only the computed result is returned.
+// Scientific notation (e.g. 1e-10) is supported and parsed as a single number.
+func ParseAmount(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty amount")
+	}
+	// Try as single number first so scientific notation (1e-10) is not treated as expression.
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f, nil
+	}
+	if !looksLikeExpression(s) {
+		return 0, fmt.Errorf("invalid amount: %q", s)
+	}
+	return evalExpr(s)
+}
+
+func looksLikeExpression(s string) bool {
+	for i, r := range s {
+		if r == '+' || r == '*' || r == '/' || r == '(' || r == ')' {
+			return true
+		}
+		if r == '-' && i > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type tokenKind int
+
+const (
+	tokNumber tokenKind = iota
+	tokAdd
+	tokSub
+	tokMul
+	tokDiv
+	tokLparen
+	tokRparen
+	tokEOF
+)
+
+type token struct {
+	kind tokenKind
+	val  float64
+}
+
+type lexer struct {
+	s   string
+	pos int
+}
+
+func (l *lexer) peek() byte {
+	if l.pos >= len(l.s) {
+		return 0
+	}
+	return l.s[l.pos]
+}
+
+func (l *lexer) advance() byte {
+	if l.pos >= len(l.s) {
+		return 0
+	}
+	b := l.s[l.pos]
+	l.pos++
+	return b
+}
+
+func (l *lexer) skipSpaces() {
+	for l.pos < len(l.s) && (l.s[l.pos] == ' ' || l.s[l.pos] == '\t') {
+		l.pos++
+	}
+}
+
+func (l *lexer) readNumber() (float64, error) {
+	start := l.pos
+	// Optional leading minus
+	if l.peek() == '-' {
+		l.advance()
+	}
+	// Integer part
+	if l.pos >= len(l.s) || !unicode.IsDigit(rune(l.s[l.pos])) {
+		return 0, fmt.Errorf("expected number at position %d", l.pos)
+	}
+	for l.pos < len(l.s) && unicode.IsDigit(rune(l.s[l.pos])) {
+		l.advance()
+	}
+	// Optional decimal part
+	if l.peek() == '.' {
+		l.advance()
+		for l.pos < len(l.s) && unicode.IsDigit(rune(l.s[l.pos])) {
+			l.advance()
+		}
+	}
+	// Optional exponent
+	if l.pos < len(l.s) && (l.s[l.pos] == 'e' || l.s[l.pos] == 'E') {
+		l.advance()
+		if l.peek() == '+' || l.peek() == '-' {
+			l.advance()
+		}
+		for l.pos < len(l.s) && unicode.IsDigit(rune(l.s[l.pos])) {
+			l.advance()
+		}
+	}
+	numStr := l.s[start:l.pos]
+	f, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number %q: %w", numStr, err)
+	}
+	return f, nil
+}
+
+func (l *lexer) next() (token, error) {
+	l.skipSpaces()
+	if l.pos >= len(l.s) {
+		return token{kind: tokEOF}, nil
+	}
+	switch l.peek() {
+	case '+':
+		l.advance()
+		return token{kind: tokAdd}, nil
+	case '-':
+		l.advance()
+		return token{kind: tokSub}, nil
+	case '*':
+		l.advance()
+		return token{kind: tokMul}, nil
+	case '/':
+		l.advance()
+		return token{kind: tokDiv}, nil
+	case '(':
+		l.advance()
+		return token{kind: tokLparen}, nil
+	case ')':
+		l.advance()
+		return token{kind: tokRparen}, nil
+	default:
+		if unicode.IsDigit(rune(l.peek())) || (l.peek() == '-' && l.pos+1 < len(l.s) && unicode.IsDigit(rune(l.s[l.pos+1]))) {
+			val, err := l.readNumber()
+			if err != nil {
+				return token{}, err
+			}
+			return token{kind: tokNumber, val: val}, nil
+		}
+		return token{}, fmt.Errorf("unexpected character %q at position %d", l.peek(), l.pos)
+	}
+}
+
+type parser struct {
+	lex   *lexer
+	tok   token
+	tokErr error
+}
+
+func (p *parser) advance() error {
+	if p.tokErr != nil {
+		return p.tokErr
+	}
+	p.tok, p.tokErr = p.lex.next()
+	return p.tokErr
+}
+
+// parseExpr parses an expression; it advances to read the first token, then parses.
+func (p *parser) parseExpr() (float64, error) {
+	if err := p.advance(); err != nil {
+		return 0, err
+	}
+	return p.parseExprContent()
+}
+
+// parseExprContent parses expression content assuming the first token is already in p.tok.
+// Used after consuming "(" so we don't skip the first token of the parenthesized expression.
+func (p *parser) parseExprContent() (float64, error) {
+	val, err := p.parseTerm()
+	if err != nil {
+		return 0, err
+	}
+	for p.tok.kind == tokAdd || p.tok.kind == tokSub {
+		op := p.tok.kind
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		rhs, err := p.parseTerm()
+		if err != nil {
+			return 0, err
+		}
+		if op == tokAdd {
+			val += rhs
+		} else {
+			val -= rhs
+		}
+	}
+	return val, nil
+}
+
+func (p *parser) parseTerm() (float64, error) {
+	val, err := p.parseFactor()
+	if err != nil {
+		return 0, err
+	}
+	for p.tok.kind == tokMul || p.tok.kind == tokDiv {
+		op := p.tok.kind
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		rhs, err := p.parseFactor()
+		if err != nil {
+			return 0, err
+		}
+		if op == tokMul {
+			val *= rhs
+		} else {
+			if rhs == 0 {
+				return 0, fmt.Errorf("division by zero")
+			}
+			val /= rhs
+		}
+	}
+	return val, nil
+}
+
+func (p *parser) parseFactor() (float64, error) {
+	switch p.tok.kind {
+	case tokNumber:
+		val := p.tok.val
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		return val, nil
+	case tokLparen:
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		// Parse expression content without advancing first (we already have the first token).
+		val, err := p.parseExprContent()
+		if err != nil {
+			return 0, err
+		}
+		if p.tok.kind != tokRparen {
+			return 0, fmt.Errorf("missing closing parenthesis")
+		}
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		return val, nil
+	case tokSub:
+		// Unary minus
+		if err := p.advance(); err != nil {
+			return 0, err
+		}
+		val, err := p.parseFactor()
+		if err != nil {
+			return 0, err
+		}
+		return -val, nil
+	default:
+		return 0, fmt.Errorf("unexpected token at position %d", p.lex.pos)
+	}
+}
+
+func evalExpr(s string) (float64, error) {
+	p := &parser{lex: &lexer{s: s}}
+	val, err := p.parseExpr()
+	if err != nil {
+		return 0, err
+	}
+	if p.tok.kind != tokEOF {
+		return 0, fmt.Errorf("unexpected token after expression")
+	}
+	return val, nil
+}

--- a/internal/ui/amount_test.go
+++ b/internal/ui/amount_test.go
@@ -1,0 +1,111 @@
+package ui
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestParseAmount_PlainNumbers(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		{"0", 0},
+		{"123", 123},
+		{"1.5", 1.5},
+		{"-42", -42},
+		{"-0.5", -0.5},
+		{"1e-10", 1e-10},
+		{"1e2", 100},
+		{"  99  ", 99},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("expression %q = %g", tt.in, tt.want), func(t *testing.T) {
+			got, err := ParseAmount(tt.in)
+			if err != nil {
+				t.Fatalf("ParseAmount(%q) err = %v", tt.in, err)
+			}
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("ParseAmount(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAmount_Expressions(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		{"1+2", 3},
+		{"10-3", 7},
+		{"2*3", 6},
+		{"10/2", 5},
+		{"1+2*3", 7},
+		{"2*3+4", 10},
+		{"10/2+3", 8},
+		{"500+23+43", 566},
+		{"500+23+43-294*1.23", 500 + 23 + 43 - 294*1.23},
+		{"(1+2)*3", 9},
+		{"2*(3+4)", 14},
+		{"(100+50)*1.23", 184.5},
+		{"((1+2)*3)+4", 13},
+		{"-5", -5},
+		{"-5+3", -2},
+		{"5*-2", -10},
+		{" 500 + 23 ", 523},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("expression %q = %g", tt.in, tt.want), func(t *testing.T) {
+			got, err := ParseAmount(tt.in)
+			if err != nil {
+				t.Fatalf("ParseAmount(%q) err = %v", tt.in, err)
+			}
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("ParseAmount(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAmount_Invalid(t *testing.T) {
+	invalid := []string{
+		"",
+		"   ",
+		"abc",
+		"1+",
+		"1++2",
+		"(1",
+		"1)",
+		")(",
+		"1/0",
+	}
+	for _, in := range invalid {
+		t.Run(fmt.Sprintf("invalid %q", in), func(t *testing.T) {
+			_, err := ParseAmount(in)
+			if err == nil {
+				t.Error("ParseAmount expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseAmount_ScientificNotationNotExpression(t *testing.T) {
+	// 1e-10 must parse as single number, not 1e minus 10
+	got, err := ParseAmount("1e-10")
+	if err != nil {
+		t.Fatalf("ParseAmount(1e-10) err = %v", err)
+	}
+	want := 1e-10
+	if math.Abs(got-want) > 1e-20 {
+		t.Errorf("ParseAmount(1e-10) = %v, want %v", got, want)
+	}
+}
+
+func TestParseAmount_DivisionByZero(t *testing.T) {
+	_, err := ParseAmount("1/0")
+	if err == nil {
+		t.Error("ParseAmount(1/0) expected error (division by zero)")
+	}
+}

--- a/internal/ui/parsing.go
+++ b/internal/ui/parsing.go
@@ -17,11 +17,11 @@ type UncertainValue struct {
 }
 
 func ParseUncertainValue(val string) (uncertain.Value, error) {
-	if unicode.IsDigit(rune(val[0])) || (len(val) > 1 && val[0] == '-' && unicode.IsDigit(rune(val[1]))) {
-		// If the value is a simple float, return a fixed uncertain value
-		f, err := shttp.ParseFloat(val)
+	if len(val) > 0 && (unicode.IsDigit(rune(val[0])) || (len(val) > 1 && val[0] == '-' && unicode.IsDigit(rune(val[1]))) || val[0] == '(') {
+		// Simple float or expression (e.g. 500+23+43-294*1.23 or (100+50)*1.23); parse and return fixed.
+		f, err := ParseAmount(val)
 		if err != nil {
-			return uncertain.Value{}, fmt.Errorf("parsing float: %w", err)
+			return uncertain.Value{}, fmt.Errorf("parsing amount: %w", err)
 		}
 		return uncertain.NewFixed(f), nil
 	}


### PR DESCRIPTION
- Add ParseAmount in internal/ui/amount.go: supports +, -, *, / and parentheses; plain numbers and scientific notation (e.g. 1e-10) parse as single values.
- Use ParseAmount in ParseUncertainValue (snapshot table balances, transfer template fixed amount) and for amount_<id> on transfers page.
- Add table-driven tests with t.Run subtests.