### PR TITLE
Include startup share balances in dashboard balance history chart

### DIFF
--- a/sqlc/queries/account.sql
+++ b/sqlc/queries/account.sql
@@ -167,6 +167,23 @@ FROM account_snapshot s
 ORDER BY s.date,
   a.type_id,
   s.account_id;
+-- name: ListStartupShareSnapshotHistory :many
+-- Returns investment rounds joined with startup share config and account type for balance history.
+SELECT ir.account_id,
+  ir.date,
+  ir.valuation,
+  ssa.shares_owned,
+  ssa.total_shares,
+  ssa.purchase_price_per_share,
+  ssa.tax_rate,
+  ssa.valuation_discount_factor,
+  COALESCE(a.type_id, '') AS type_id
+FROM investment_round ir
+  JOIN startup_share_account ssa ON ssa.account_id = ir.account_id
+  JOIN account a ON a.id = ir.account_id
+ORDER BY ir.date,
+  a.type_id,
+  ir.account_id;
 -- name: ListActiveGrowthModels :many
 SELECT *
 FROM growth_model


### PR DESCRIPTION
## Summary

- Added `ListStartupShareSnapshotHistory` SQL query to fetch investment rounds joined with startup share config and account type
- Modified `buildSnapshotHistoryChart` to compute startup share balances for each chart date using the latest investment round on or before that date
- Only generates balances for the dates already shown in the chart (from regular account snapshots), not for every investment round date

Fixes #48

Made with [Cursor](https://cursor.com)