### PR TITLE
Replace context.Background() with t.Context() in tests

### DIFF
--- a/internal/finance/core_test.go
+++ b/internal/finance/core_test.go
@@ -104,7 +104,7 @@ func mks[T any](accounts ...T) []T {
 	return accounts
 }
 
-func runPredict(accounts []finance.Entity, transfers []finance.TransferTemplate) (map[string]uncertain.Value, error) {
+func runPredict(ctx context.Context, accounts []finance.Entity, transfers []finance.TransferTemplate) (map[string]uncertain.Value, error) {
 	m := make(map[string]finance.BalanceSnapshot)
 	snapshotRecorder := finance.SnapshotRecorderFunc(func(accountID string, day date.Date, balance uncertain.Value) error {
 		if s, ok := m[accountID]; !ok || s.Date < day {
@@ -116,7 +116,7 @@ func runPredict(accounts []finance.Entity, transfers []finance.TransferTemplate)
 		return nil
 	})
 	err := finance.RunPrediction(
-		context.Background(),
+		ctx,
 		uncertain.NewConfig(time.Now().UnixMilli(), 2_000),
 		startDate,
 		startDate.Add(1*date.Year).Add(2*date.Day),
@@ -157,7 +157,7 @@ func TestMortgageInterestPayments(t *testing.T) {
 		withInterest(uncertain.NewFixed(0.03), "*-*-01", checkAcc.ID),
 		withBalance(firstDate, uncertain.NewFixed(-10000)),
 	)
-	bals, err := runPredict(mks(*checkAcc, *mortgAcc), nil)
+	bals, err := runPredict(t.Context(), mks(*checkAcc, *mortgAcc), nil)
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}
@@ -174,7 +174,7 @@ func TestSavingsAccountInterestPayments(t *testing.T) {
 		withLogNormGrowth(uncertain.NewFixed(0.04), uncertain.NewFixed(0.04)),
 		withBalance(firstDate, uncertain.NewFixed(1000)),
 	)
-	bals, err := runPredict(mks(*savingsAcc), nil)
+	bals, err := runPredict(t.Context(), mks(*savingsAcc), nil)
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}
@@ -186,7 +186,7 @@ func TestSavingsAccountInterestPayments(t *testing.T) {
 func TestTransfersToAndFromExternal(t *testing.T) {
 	salaryAcc := newAccount("Salary Account")
 	salaryTrn := newTransfer("", salaryAcc.ID, 1, "*-*-25", withFixed(uncertain.NewFixed(1000)))
-	bals, err := runPredict(mks(*salaryAcc), mks(salaryTrn))
+	bals, err := runPredict(t.Context(), mks(*salaryAcc), mks(salaryTrn))
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}
@@ -199,7 +199,7 @@ func TestTransfersBetweenAccounts(t *testing.T) {
 	checkingAcc := newAccount("Checking Account", withBalance(firstDate, uncertain.NewFixed(13000)))
 	savingsAcc := newAccount("Savings Account")
 	savingsTrn := newTransfer(checkingAcc.ID, savingsAcc.ID, 1, "*-*-25", withFixed(uncertain.NewFixed(1000)))
-	bals, err := runPredict(mks(*checkingAcc, *savingsAcc), mks(savingsTrn))
+	bals, err := runPredict(t.Context(), mks(*checkingAcc, *savingsAcc), mks(savingsTrn))
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}
@@ -216,7 +216,7 @@ func TestRealEstateAppreciation(t *testing.T) {
 		withBalance(firstDate, uncertain.NewUniform(99_000, 101_000)),
 		withGrowthModel(uncertain.NewUniform(0.00, 0.06)),
 	)
-	bals, err := runPredict(mks(*realEstateAcc), nil)
+	bals, err := runPredict(t.Context(), mks(*realEstateAcc), nil)
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}
@@ -231,7 +231,7 @@ func BenchmarkRealEstateAppreciation(b *testing.B) {
 		withGrowthModel(uncertain.NewUniform(0.00, 0.06)),
 	)
 	for b.Loop() {
-		if _, err := runPredict(mks(*realEstateAcc), nil); err != nil {
+		if _, err := runPredict(b.Context(), mks(*realEstateAcc), nil); err != nil {
 			b.Fatalf("failed to run simulation: %s", err)
 		}
 	}
@@ -245,7 +245,7 @@ func TestInterestForwardingUntilFromDate(t *testing.T) {
 	)
 	salary := newTransfer("", checkingAcc.ID, 1, "*-*-25", withFixed(uncertain.NewFixed(10_000)))
 	transfer := newTransfer(checkingAcc.ID, savingsAcc.ID, 1, "*-01-24", withFixed(uncertain.NewFixed(1000)))
-	bals, err := runPredict(mks(*checkingAcc, *savingsAcc), mks(salary, transfer))
+	bals, err := runPredict(t.Context(), mks(*checkingAcc, *savingsAcc), mks(salary, transfer))
 	if err != nil {
 		t.Fatalf("failed to run simulation: %s", err)
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,7 +1,6 @@
 package service_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/SimonSchneider/goslu/date"
@@ -27,7 +26,7 @@ func mustParseDate(s string) date.Date {
 
 func newTestService(t *testing.T) *service.Service {
 	t.Helper()
-	db, err := service.GetMigratedDB(context.Background(), pefigo.StaticEmbeddedFS, "static/migrations", ":memory:")
+	db, err := service.GetMigratedDB(t.Context(), pefigo.StaticEmbeddedFS, "static/migrations", ":memory:")
 	if err != nil {
 		t.Fatalf("failed to create test db: %v", err)
 	}
@@ -39,7 +38,7 @@ func newTestService(t *testing.T) *service.Service {
 
 func TestAccountTypeCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at, err := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Savings", Color: "#00ff00"})
 	if err != nil {
@@ -89,7 +88,7 @@ func TestAccountTypeCRUD(t *testing.T) {
 
 func TestCategoryCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	color := "#abcdef"
 	cat, err := svc.UpsertCategory(ctx, service.TransferTemplateCategoryInput{Name: "Housing", Color: &color})
@@ -125,7 +124,7 @@ func TestCategoryCRUD(t *testing.T) {
 
 func TestAccountCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at, err := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Checking"})
 	if err != nil {
@@ -180,7 +179,7 @@ func TestAccountCRUD(t *testing.T) {
 
 func TestSpecialDateCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sd, err := svc.UpsertSpecialDate(ctx, service.SpecialDateInput{Name: "Christmas", Date: mustParseDate("2025-12-25"), Color: "#ff0000"})
 	if err != nil {
@@ -215,7 +214,7 @@ func TestSpecialDateCRUD(t *testing.T) {
 
 func TestSnapshotCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	acc, err := svc.UpsertAccount(ctx, service.AccountInput{Name: "Test"})
 	if err != nil {
@@ -258,7 +257,7 @@ func TestSnapshotCRUD(t *testing.T) {
 
 func TestTransferTemplateCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	acc1, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "From"})
 	acc2, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "To"})
@@ -316,7 +315,7 @@ func TestTransferTemplateCRUD(t *testing.T) {
 
 func TestGrowthModelCRUD(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	acc, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "Savings"})
 
@@ -351,7 +350,7 @@ func TestGrowthModelCRUD(t *testing.T) {
 
 func TestGetDashboardData(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at, _ := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Savings", Color: "#00ff00"})
 	acc, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "My Savings", TypeID: at.ID})
@@ -382,7 +381,7 @@ func TestGetDashboardData(t *testing.T) {
 
 func TestGetBudgetData(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	color := "#ff0000"
 	cat, _ := svc.UpsertCategory(ctx, service.TransferTemplateCategoryInput{Name: "Housing", Color: &color})
@@ -420,7 +419,7 @@ func TestGetBudgetData(t *testing.T) {
 
 func TestGetCategoriesPageData(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at, err := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Savings", Color: "#00ff00"})
 	if err != nil {
@@ -453,7 +452,7 @@ func TestGetCategoriesPageData(t *testing.T) {
 
 func TestGetCategoriesPageDataEmpty(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	view, err := svc.GetCategoriesPageData(ctx)
 	if err != nil {
@@ -471,7 +470,7 @@ func TestGetCategoriesPageDataEmpty(t *testing.T) {
 
 func TestGetTransferChartData_NodeColorsFromAccountTypes(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at1, _ := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Savings", Color: "#00ff00"})
 	at2, _ := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Checking", Color: "#0000ff"})
@@ -597,7 +596,7 @@ func TestSimplifyTransfersRemovesSelfAndExternal(t *testing.T) {
 
 func TestListAccountsDetailed(t *testing.T) {
 	svc := newTestService(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	at, _ := svc.UpsertAccountType(ctx, service.AccountTypeInput{Name: "Bank"})
 	acc, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "Savings", TypeID: at.ID})


### PR DESCRIPTION
## Summary
- Replaced all `context.Background()` calls with `t.Context()` / `b.Context()` in test files, leveraging Go 1.24+'s `testing.T.Context()` for proper test-scoped contexts
- Updated `internal/service/service_test.go`: 14 replacements, removed unused `"context"` import
- Updated `internal/finance/core_test.go`: added `context.Context` parameter to `runPredict` helper, updated all 7 call sites

Fixes #64

Made with [Cursor](https://cursor.com)