### PR TITLE
Fix child template amounts and include children in transfer calculator

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,18 @@
+# Testing
+
+Testing should focus mainly on Models (service layer). It's important only to excercise the public API used by Controllers.
+
+Tests should be in a `_test` package. ie.
+
+the package
+```
+package service
+```
+should be tested in the same directory but tests should have the package
+```
+package service_test
+```
+
+**Do not export APIs only for testing, use the public API excercised by the Controllers only.**
+
+Tests should mainly be integration tests with real DB and as close as possible to the real world with no mocking and no partial tests, they should excercise the models just like the controllers do.

--- a/internal/core/view_transfer_templates.templ
+++ b/internal/core/view_transfer_templates.templ
@@ -413,12 +413,12 @@ templ TransferTemplatesContent(view *TransferTemplatesView2) {
 											if !isChild {
 												@TransferTemplateTableRow(view, &tpl)
 												{{ rendered[tpl.ID] = true }}
-												if isParent {
-													for _, child := range tpl.ChildTemplates {
-														{{ childWithAmount := TransferTemplateWithAmount{TransferTemplate: child, SimDate: tpl.SimDate, Amount: 0} }}
-														@TransferTemplateTableRow(view, &childWithAmount)
-														{{ rendered[child.ID] = true }}
-													}
+											if isParent {
+												for _, child := range tpl.ChildTemplates {
+													{{ childWithAmount := view.GetChildWithAmount(child) }}
+													@TransferTemplateTableRow(view, &childWithAmount)
+													{{ rendered[child.ID] = true }}
+												}
 												}
 											}
 										}

--- a/internal/core/view_transfer_templates_templ.go
+++ b/internal/core/view_transfer_templates_templ.go
@@ -1154,7 +1154,7 @@ func TransferTemplatesContent(view *TransferTemplatesView2) templ.Component {
 					rendered[tpl.ID] = true
 					if isParent {
 						for _, child := range tpl.ChildTemplates {
-							childWithAmount := TransferTemplateWithAmount{TransferTemplate: child, SimDate: tpl.SimDate, Amount: 0}
+							childWithAmount := view.GetChildWithAmount(child)
 							templ_7745c5c3_Err = TransferTemplateTableRow(view, &childWithAmount).Render(ctx, templ_7745c5c3_Buffer)
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -626,3 +626,170 @@ func TestListAccountsDetailed(t *testing.T) {
 		t.Fatal("expected non-nil growth model")
 	}
 }
+
+// ---- Transfer Template Child Amount Computation ----
+
+func TestGetTransferTemplatesPageData_ChildAmountsComputed(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	pastEnd := mustParseDate("2020-12-31")
+	parent, err := svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:        "Rent",
+		AmountType:  "fixed",
+		AmountFixed: newFixedValue(1500),
+		Priority:    1,
+		Recurrence:  "*-*-01",
+		StartDate:   mustParseDate("2020-01-01"),
+		EndDate:     &pastEnd,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	_, err = svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:             "Rent",
+		AmountType:       "fixed",
+		AmountFixed:      newFixedValue(2000),
+		Priority:         1,
+		Recurrence:       "*-*-01",
+		StartDate:        mustParseDate("2020-01-01"),
+		Enabled:          true,
+		ParentTemplateID: &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	view, err := svc.GetTransferTemplatesPageData(ctx)
+	if err != nil {
+		t.Fatalf("GetTransferTemplatesPageData: %v", err)
+	}
+
+	if len(view.TransferTemplates) != 1 {
+		t.Fatalf("expected 1 root template, got %d", len(view.TransferTemplates))
+	}
+
+	parentTpl := view.TransferTemplates[0]
+	if parentTpl.Amount != 0 {
+		t.Errorf("inactive parent: expected amount 0, got %f", parentTpl.Amount)
+	}
+
+	if len(parentTpl.ChildTemplates) != 1 {
+		t.Fatalf("expected 1 child template, got %d", len(parentTpl.ChildTemplates))
+	}
+
+	childWithAmount := view.GetChildWithAmount(parentTpl.ChildTemplates[0])
+	if childWithAmount.Amount != 2000 {
+		t.Errorf("active child: expected amount 2000, got %f", childWithAmount.Amount)
+	}
+}
+
+func TestGetTransferTemplatesPageData_ActiveChildContributesToMonthlyIncome(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	acc, err := svc.UpsertAccount(ctx, service.AccountInput{Name: "Checking"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	pastEnd := mustParseDate("2020-12-31")
+	parent, err := svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:        "Salary",
+		ToAccountID: acc.ID,
+		AmountType:  "fixed",
+		AmountFixed: newFixedValue(4000),
+		Priority:    1,
+		Recurrence:  "*-*-25",
+		StartDate:   mustParseDate("2020-01-01"),
+		EndDate:     &pastEnd,
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	_, err = svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:             "Salary",
+		ToAccountID:      acc.ID,
+		AmountType:       "fixed",
+		AmountFixed:      newFixedValue(5000),
+		Priority:         1,
+		Recurrence:       "*-*-25",
+		StartDate:        mustParseDate("2020-01-01"),
+		Enabled:          true,
+		ParentTemplateID: &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	view, err := svc.GetTransferTemplatesPageData(ctx)
+	if err != nil {
+		t.Fatalf("GetTransferTemplatesPageData: %v", err)
+	}
+
+	if view.MonthlyIncome != 5000 {
+		t.Errorf("expected monthly income 5000 from active child, got %f", view.MonthlyIncome)
+	}
+}
+
+func TestComputeTransfersView_IncludesActiveChildOfInactiveParent(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	acc1, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "Checking"})
+	acc2, _ := svc.UpsertAccount(ctx, service.AccountInput{Name: "Savings"})
+
+	pastEnd := mustParseDate("2024-12-31")
+	parent, err := svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:          "Rent",
+		FromAccountID: acc1.ID,
+		ToAccountID:   acc2.ID,
+		AmountType:    "fixed",
+		AmountFixed:   newFixedValue(1500),
+		Priority:      1,
+		Recurrence:    "*-*-01",
+		StartDate:     mustParseDate("2020-01-01"),
+		EndDate:       &pastEnd,
+		Enabled:       true,
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	child, err := svc.UpsertTransferTemplate(ctx, service.TransferTemplate{
+		Name:             "Rent",
+		FromAccountID:    acc1.ID,
+		ToAccountID:      acc2.ID,
+		AmountType:       "fixed",
+		AmountFixed:      newFixedValue(2000),
+		Priority:         1,
+		Recurrence:       "*-*-01",
+		StartDate:        mustParseDate("2025-01-01"),
+		Enabled:          true,
+		ParentTemplateID: &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	day := mustParseDate("2025-06-01")
+	view, err := svc.ComputeTransfersView(ctx, day, nil)
+	if err != nil {
+		t.Fatalf("ComputeTransfersView: %v", err)
+	}
+
+	found := false
+	for _, tt := range view.TransferTemplates {
+		if tt.ID == child.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("active child template %s not found in TransfersView; parent-child should be a visual grouping only", child.ID)
+	}
+}

--- a/internal/service/transfers.go
+++ b/internal/service/transfers.go
@@ -32,7 +32,7 @@ type Transfer struct {
 
 func (s *Service) ComputeTransfersView(ctx context.Context, day date.Date, amounts map[string]float64) (*TransfersView, error) {
 	view := &TransfersView{Day: day}
-	allTransferTemplates, err := s.ListTransferTemplatesWithChildren(ctx)
+	allTransferTemplates, err := s.ListTransferTemplates(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing transfer templates: %w", err)
 	}

--- a/internal/service/view.go
+++ b/internal/service/view.go
@@ -89,20 +89,47 @@ type TransferTemplatesView2 struct {
 	Categories        map[string]TransferTemplateCategory
 	MonthlyIncome     float64
 	MonthlyExpenses   float64
+	childAmounts      map[string]TransferTemplateWithAmount
 }
 
-func NewTransferTemplatesView2(transferTemplates []TransferTemplate, accounts []Account, categories []TransferTemplateCategory) *TransferTemplatesView2 {
+func (v *TransferTemplatesView2) GetChildWithAmount(child TransferTemplate) TransferTemplateWithAmount {
+	if a, ok := v.childAmounts[child.ID]; ok {
+		return a
+	}
+	return TransferTemplateWithAmount{TransferTemplate: child}
+}
+
+func newTransferTemplatesView2(transferTemplates []TransferTemplate, accounts []Account, categories []TransferTemplateCategory) *TransferTemplatesView2 {
+	day := date.Today()
 	v := &TransferTemplatesView2{
-		TransferTemplates: MakeTransferTemplatesWithAmount(transferTemplates, date.Today()),
+		TransferTemplates: MakeTransferTemplatesWithAmount(transferTemplates, day),
 		Accounts:          KeyBy(accounts, func(a Account) string { return a.ID }),
 		Categories:        KeyBy(categories, func(c TransferTemplateCategory) string { return c.ID }),
+		childAmounts:      make(map[string]TransferTemplateWithAmount),
 	}
-	for _, t := range v.TransferTemplates {
+
+	var children []TransferTemplate
+	for _, t := range transferTemplates {
+		children = append(children, t.ChildTemplates...)
+	}
+	if len(children) > 0 {
+		for _, c := range MakeTransferTemplatesWithAmount(children, day) {
+			v.childAmounts[c.ID] = c
+		}
+	}
+
+	addToMonthlyTotals := func(t TransferTemplateWithAmount) {
 		if t.FromAccountID == "" {
 			v.MonthlyIncome += t.Amount
 		} else if t.ToAccountID == "" {
 			v.MonthlyExpenses += -t.Amount
 		}
+	}
+	for _, t := range v.TransferTemplates {
+		addToMonthlyTotals(t)
+	}
+	for _, t := range v.childAmounts {
+		addToMonthlyTotals(t)
 	}
 	return v
 }
@@ -421,7 +448,7 @@ func (s *Service) GetTransferTemplatesPageData(ctx context.Context) (*TransferTe
 	if err != nil {
 		return nil, fmt.Errorf("listing categories: %w", err)
 	}
-	return NewTransferTemplatesView2(transferTemplates, accounts, categories), nil
+	return newTransferTemplatesView2(transferTemplates, accounts, categories), nil
 }
 
 func (s *Service) GetTransferTemplateNewPageData(ctx context.Context) (*TransferTemplateEditView, error) {


### PR DESCRIPTION
## Summary

- **Transfer calculator bug**: `ComputeTransfersView` used `ListTransferTemplatesWithChildren` (roots only), making active child templates invisible when their parent was inactive. Switched to `ListTransferTemplates` (flat list) since parent-child is a purely visual grouping.
- **Display bug**: The transfer templates page hardcoded `Amount: 0` for children. Added `GetChildWithAmount` and child amount computation so children display correct amounts and contribute to monthly income/expense totals.
- Unexported `NewTransferTemplatesView2` → `newTransferTemplatesView2` since it's only called internally.

## Test plan

- [x] `TestComputeTransfersView_IncludesActiveChildOfInactiveParent` — active child templates appear in the transfer calculator even when parent is inactive
- [x] `TestGetTransferTemplatesPageData_ChildAmountsComputed` — child template amounts are correctly computed and accessible via `GetChildWithAmount`
- [x] `TestGetTransferTemplatesPageData_ActiveChildContributesToMonthlyIncome` — active income children contribute to monthly totals
- [x] Full test suite passes

Fixes #67

Made with [Cursor](https://cursor.com)