### PR TITLE
Exclude one-time transfers from monthly totals

### DIFF
--- a/internal/service/view.go
+++ b/internal/service/view.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/SimonSchneider/goslu/date"
 	"github.com/SimonSchneider/pefigo/internal/currency"
@@ -141,8 +142,10 @@ func newTransferTemplatesView2(flatTemplates []TransferTemplate, groupedTemplate
 	}
 
 	// Monthly totals computed from flat amounts — grouping is purely visual.
+	// One-time transfers (no wildcard in recurrence) are excluded since they
+	// are not part of the monthly recurring transfers.
 	for _, twa := range flatAmounts {
-		if twa.Amount == 0 {
+		if twa.Amount == 0 || !strings.Contains(string(twa.Recurrence), "*") {
 			continue
 		}
 		if twa.FromAccountID == "" {

--- a/internal/service/view_test.go
+++ b/internal/service/view_test.go
@@ -2,7 +2,59 @@ package service
 
 import (
 	"testing"
+
+	"github.com/SimonSchneider/pefigo/internal/uncertain"
 )
+
+func TestNewTransferTemplatesView2_OneTimeTransfersExcludedFromMonthlyTotals(t *testing.T) {
+	templates := []TransferTemplate{
+		{
+			ID:          "recurring-income",
+			Name:        "Salary",
+			ToAccountID: "acc1",
+			AmountType:  "fixed",
+			AmountFixed: uncertain.NewFixed(5000),
+			Recurrence:  "*-*-25",
+			Enabled:     true,
+		},
+		{
+			ID:          "onetime-income",
+			Name:        "Bonus",
+			ToAccountID: "acc1",
+			AmountType:  "fixed",
+			AmountFixed: uncertain.NewFixed(10000),
+			Recurrence:  "2024-06-01",
+			Enabled:     true,
+		},
+		{
+			ID:            "recurring-expense",
+			Name:          "Rent",
+			FromAccountID: "acc1",
+			AmountType:    "fixed",
+			AmountFixed:   uncertain.NewFixed(1200),
+			Recurrence:    "*-*-1",
+			Enabled:       true,
+		},
+		{
+			ID:            "onetime-expense",
+			Name:          "Moving cost",
+			FromAccountID: "acc1",
+			AmountType:    "fixed",
+			AmountFixed:   uncertain.NewFixed(3000),
+			Recurrence:    "2024-06-01",
+			Enabled:       true,
+		},
+	}
+
+	view := newTransferTemplatesView2(templates, templates, nil, nil)
+
+	if view.MonthlyIncome != 5000 {
+		t.Errorf("expected MonthlyIncome 5000 (excluding one-time bonus), got %f", view.MonthlyIncome)
+	}
+	if view.MonthlyExpenses != -1200 {
+		t.Errorf("expected MonthlyExpenses -1200 (excluding one-time moving cost), got %f", view.MonthlyExpenses)
+	}
+}
 
 func TestAccountFormMode(t *testing.T) {
 	t.Run("standard when no startup share account", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- One-time transfer templates (specific date recurrence, no `*` wildcards) are no longer included in MonthlyIncome, MonthlyExpenses, and Net Income totals
- Aligns with the existing budget logic which already filters one-time transfers

Closes #70

## Test plan
- [x] Unit test verifying one-time income and expense templates are excluded from monthly totals
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)