### PR TITLE
fix: sort forecast chart tooltip items descending

### DIFF
--- a/static/public/dashboard-forecast.js
+++ b/static/public/dashboard-forecast.js
@@ -126,6 +126,7 @@
                         return p.value && p.value[1] !== 0;
                     });
                     if (items.length === 0) return '';
+                    items.sort(function(a, b) { return b.value[1] - a.value[1]; });
                     var date = new Date(items[0].value[0]);
                     var header = date.getFullYear() + '-' + String(date.getMonth()+1).padStart(2,'0') + '-' + String(date.getDate()).padStart(2,'0');
                     var total = items.reduce(function(sum, p) { return sum + p.value[1]; }, 0);


### PR DESCRIPTION
## Summary
- Sort the dashboard forecast prediction chart's tooltip items by value descending, matching the snapshot history chart's tooltip behavior.

Closes #112

## Test plan
- [ ] Hover over the dashboard forecast chart and confirm series are listed largest-to-smallest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)