### PR TITLE
feat: today marker on dashboard forecast + invalidate cache on salary changes

### DIFF
--- a/internal/model/forecast_cache.go
+++ b/internal/model/forecast_cache.go
@@ -170,7 +170,11 @@ func (s *Service) GetForecastCacheForDashboard(ctx context.Context) (*ForecastDa
 	if err != nil {
 		return nil, fmt.Errorf("listing special dates: %w", err)
 	}
-	marklines := make([]Markline, 0, len(specialDates))
+	marklines := make([]Markline, 0, len(specialDates)+1)
+	marklines = append(marklines, Markline{
+		Date: date.Today().ToStdTime().UnixMilli(),
+		Name: "Today",
+	})
 	for _, sd := range specialDates {
 		marklines = append(marklines, Markline{
 			Date:  sd.Date.ToStdTime().UnixMilli(),

--- a/internal/model/salary.go
+++ b/internal/model/salary.go
@@ -223,6 +223,7 @@ func (s *Service) UpsertSalary(ctx context.Context, inp Salary) (Salary, error) 
 	if err != nil {
 		return Salary{}, fmt.Errorf("upserting salary: %w", err)
 	}
+	s.invalidateForecast()
 	return salaryFromDB(sal), nil
 }
 
@@ -271,6 +272,7 @@ func (s *Service) DeleteSalary(ctx context.Context, id string) error {
 	if err := s.q.DeleteSalary(ctx, id); err != nil {
 		return fmt.Errorf("deleting salary: %w", err)
 	}
+	s.invalidateForecast()
 	return nil
 }
 
@@ -294,6 +296,7 @@ func (s *Service) UpsertSalaryAmount(ctx context.Context, inp SalaryAmount) (Sal
 	if err != nil {
 		return SalaryAmount{}, fmt.Errorf("upserting salary amount: %w", err)
 	}
+	s.invalidateForecast()
 	return salaryAmountFromDB(a)
 }
 
@@ -317,6 +320,7 @@ func (s *Service) DeleteSalaryAmount(ctx context.Context, id string) error {
 	if err := s.q.DeleteSalaryAmount(ctx, id); err != nil {
 		return fmt.Errorf("deleting salary amount: %w", err)
 	}
+	s.invalidateForecast()
 	return nil
 }
 
@@ -351,6 +355,7 @@ func (s *Service) UpsertSalaryAdjustment(ctx context.Context, inp SalaryAdjustme
 	if err != nil {
 		return SalaryAdjustment{}, fmt.Errorf("upserting salary adjustment: %w", err)
 	}
+	s.invalidateForecast()
 	return salaryAdjustmentFromDB(a), nil
 }
 
@@ -370,6 +375,7 @@ func (s *Service) DeleteSalaryAdjustment(ctx context.Context, id string) error {
 	if err := s.q.DeleteSalaryAdjustment(ctx, id); err != nil {
 		return fmt.Errorf("deleting salary adjustment: %w", err)
 	}
+	s.invalidateForecast()
 	return nil
 }
 
@@ -404,6 +410,7 @@ func (s *Service) UpsertPartialParentalLeave(ctx context.Context, inp PartialPar
 	if err != nil {
 		return PartialParentalLeave{}, fmt.Errorf("upserting partial parental leave: %w", err)
 	}
+	s.invalidateForecast()
 	return partialParentalLeaveFromDB(a), nil
 }
 
@@ -423,6 +430,7 @@ func (s *Service) DeletePartialParentalLeave(ctx context.Context, id string) err
 	if err := s.q.DeletePartialParentalLeave(ctx, id); err != nil {
 		return fmt.Errorf("deleting partial parental leave: %w", err)
 	}
+	s.invalidateForecast()
 	return nil
 }
 
@@ -453,6 +461,7 @@ func (s *Service) UpsertFullParentalLeave(ctx context.Context, inp FullParentalL
 	if err != nil {
 		return FullParentalLeave{}, fmt.Errorf("upserting full parental leave: %w", err)
 	}
+	s.invalidateForecast()
 	return fullParentalLeaveFromDB(a), nil
 }
 
@@ -472,6 +481,7 @@ func (s *Service) DeleteFullParentalLeave(ctx context.Context, id string) error 
 	if err := s.q.DeleteFullParentalLeave(ctx, id); err != nil {
 		return fmt.Errorf("deleting full parental leave: %w", err)
 	}
+	s.invalidateForecast()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Append a "Today" markline to the dashboard forecast data, matching the forecast page chart's behavior (`internal/model/chart.go:106-110`).
- Call `invalidateForecast()` on all salary mutations (salary, amounts, adjustments, partial/full parental leaves). These are forecast inputs but were the only mutating service missing the cache-invalidation hook, leaving the dashboard forecast stale after salary edits.

Closes #111

## Test plan
- [ ] Open dashboard, confirm a "Today" vertical marker is rendered on the forecast chart at the current date alongside the special-date markers.
- [ ] Edit a salary, salary amount, or adjustment and confirm the dashboard forecast reflects the change on next view (cache is recomputed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)